### PR TITLE
BUGIFX: deletion of a key-value pair when the value is not unique

### DIFF
--- a/contracts/HitchensOrderStatisticsTreeLib.sol
+++ b/contracts/HitchensOrderStatisticsTreeLib.sol
@@ -236,8 +236,9 @@ library HitchensOrderStatisticsTreeLib {
         require(keyExists(self,key,value), "OrderStatisticsTree(408) - Value to delete does not exist.");
         Node storage nValue = self.nodes[value];
         uint rowToDelete = nValue.keyMap[key];
-        nValue.keys[rowToDelete] = nValue.keys[nValue.keys.length - uint(1)];
-        nValue.keyMap[key]=rowToDelete;
+        uint last = nValue.keys[nValue.keys.length - uint(1)];
+        nValue.keys[rowToDelete] = last;
+        nValue.keyMap[last] = rowToDelete;
         nValue.keys.length--;
         uint probe;
         uint cursor;

--- a/contracts/HitchensOrderStatisticsTreeLib.sol
+++ b/contracts/HitchensOrderStatisticsTreeLib.sol
@@ -236,7 +236,7 @@ library HitchensOrderStatisticsTreeLib {
         require(keyExists(self,key,value), "OrderStatisticsTree(408) - Value to delete does not exist.");
         Node storage nValue = self.nodes[value];
         uint rowToDelete = nValue.keyMap[key];
-        uint last = nValue.keys[nValue.keys.length - uint(1)];
+        bytes32 last = nValue.keys[nValue.keys.length - uint(1)];
         nValue.keys[rowToDelete] = last;
         nValue.keyMap[last] = rowToDelete;
         nValue.keys.length--;


### PR DESCRIPTION
Moving the last key to the "hole" left by the deleted key was reflected incorrectly in keyMap.