### PR TITLE
out of range when more than one key per value

### DIFF
--- a/contracts/HitchensOrderStatisticsTreeLib.sol
+++ b/contracts/HitchensOrderStatisticsTreeLib.sol
@@ -161,7 +161,12 @@ library HitchensOrderStatisticsTreeLib {
                     } else {
                         cursor = c.left;
                         c = self.nodes[cursor];
-                        smaller -= (keyCount + getNodeCount(self,c.right));
+                        if (smaller >= (keyCount + getNodeCount(self, c.right))) {
+                            smaller -= (keyCount + getNodeCount(self, c.right));
+                        } else {
+                            smaller = 0;
+                            finished = true;
+                        }
                     }
                 }
                 if (!exists(self,cursor)) {
@@ -191,7 +196,12 @@ library HitchensOrderStatisticsTreeLib {
                 } else {
                     cursor = c.left;
                     c = self.nodes[cursor];
-                    smaller -= (keyCount + getNodeCount(self,c.right));
+                    if (smaller >= (keyCount + getNodeCount(self, c.right))) {
+                        smaller -= (keyCount + getNodeCount(self, c.right));
+                    } else {
+                        smaller = 0;
+                        finished = true;
+                    }
                 }
             }
             if (!exists(self,cursor)) {


### PR DESCRIPTION
After entering the following kv pairs I was getting out of range panics when using `rank` or `atRank`:
```json
{
  "0x000000000000000000000000c795344b1b30e3cfee1afa1d5204b141940cf445": 200,
  "0x00000000000000000000000021c8d946027dcada77f4dc90802ea9b906d3cce4": 268,
  "0x00000000000000000000000047e65bc714cd44959360ac0814a5fca0f5b07145": 268,
  "0x00000000000000000000000030ce3ced12f1facf02fe0da8578f809f5e4937e4": 400
}
```

Value `268` exists twice but while looping through the `smaller` became negative.

Maybe this didn't panic in older versions of solidity?